### PR TITLE
fix: Replace TimeoutError with fmt.Errorf to wrap context.DeadlineExceeded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ This library integrates [gojq](https://github.com/itchyny/gojq) and [go-yamlform
 - Actual compilation happens at execution time when variables are known
 - This allows pipeline reuse with different variables
 
+### Error Handling
+- All error types (`QueryError`, `ConversionError`, `TimeoutError`) implement the `error` interface with `Unwrap()` method
+- Supports Go 1.13+ error handling patterns with `errors.Is()` and `errors.As()`
+- `TimeoutError` wraps `context.DeadlineExceeded` for idiomatic timeout checking
+- The `Duration` field in `TimeoutError` reflects the configured timeout (via `WithTimeout`), not the actual elapsed time
+
 ## Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go tool cover -html=coverage.out -o coverage.html
 ## Before Committing
 
 Always run `make all` before committing to ensure:
-- Code formatting is correct (uses gofumpt)
+- Code formatting is correct (uses golangci-lint fmt)
 - All linting checks pass (golangci-lint)
 - All tests pass with race detection enabled
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,19 @@ go test -v -race -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out -o coverage.html
 ```
 
+## Before Committing
+
+Always run `make all` before committing to ensure:
+- Code formatting is correct (uses gofumpt)
+- All linting checks pass (golangci-lint)
+- All tests pass with race detection enabled
+
+```bash
+make all
+```
+
+If formatting issues are found, run `make fmt` to fix them automatically.
+
 ## Examples
 
 See the `examples/` directory for complete examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,9 @@ This library integrates [gojq](https://github.com/itchyny/gojq) and [go-yamlform
 - This allows pipeline reuse with different variables
 
 ### Error Handling
-- All error types (`QueryError`, `ConversionError`, `TimeoutError`) implement the `error` interface with `Unwrap()` method
+- All error types (`QueryError`, `ConversionError`) implement the `error` interface with `Unwrap()` method
 - Supports Go 1.13+ error handling patterns with `errors.Is()` and `errors.As()`
-- `TimeoutError` wraps `context.DeadlineExceeded` for idiomatic timeout checking
-- The `Duration` field in `TimeoutError` reflects the configured timeout (via `WithTimeout`), not the actual elapsed time
+- Timeout errors are returned as `fmt.Errorf` wrapped `context.DeadlineExceeded` with timeout duration in the message
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ err := p.Execute(ctx, map[string]interface{}{"message": "Hello, World!"},
 - `QueryError` - jq query compilation or execution errors
 - `ConversionError` - Data conversion errors
 
-All error types implement the `Unwrap()` method for Go 1.13+ error handling. Timeout errors are returned as wrapped `context.DeadlineExceeded` errors:
+The exported error types (`QueryError`, `ConversionError`) implement the `Unwrap()` method for Go 1.13+ error handling. Timeout errors are returned as wrapped `context.DeadlineExceeded` errors:
 
 ```go
 // Check if an error is due to timeout

--- a/README.md
+++ b/README.md
@@ -247,7 +247,22 @@ err := p.Execute(ctx, map[string]interface{}{"message": "Hello, World!"},
 
 - `QueryError` - jq query compilation or execution errors
 - `ConversionError` - Data conversion errors
-- `TimeoutError` - Execution timeout errors
+- `TimeoutError` - Execution timeout errors (wraps `context.DeadlineExceeded`)
+
+All error types implement the `Unwrap()` method for Go 1.13+ error handling:
+
+```go
+// Check if an error is due to timeout
+if errors.Is(err, context.DeadlineExceeded) {
+    // This works even when err is *TimeoutError
+    log.Println("Operation timed out")
+}
+
+// Extract the specific error type
+var timeoutErr *jqyaml.TimeoutError
+if errors.As(err, &timeoutErr) {
+    log.Printf("Timeout after %s\n", timeoutErr.Duration)
+}
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -247,21 +247,14 @@ err := p.Execute(ctx, map[string]interface{}{"message": "Hello, World!"},
 
 - `QueryError` - jq query compilation or execution errors
 - `ConversionError` - Data conversion errors
-- `TimeoutError` - Execution timeout errors (wraps `context.DeadlineExceeded`)
 
-All error types implement the `Unwrap()` method for Go 1.13+ error handling:
+All error types implement the `Unwrap()` method for Go 1.13+ error handling. Timeout errors are returned as wrapped `context.DeadlineExceeded` errors:
 
 ```go
 // Check if an error is due to timeout
 if errors.Is(err, context.DeadlineExceeded) {
-    // This works even when err is *TimeoutError
-    log.Println("Operation timed out")
-}
-
-// Extract the specific error type
-var timeoutErr *jqyaml.TimeoutError
-if errors.As(err, &timeoutErr) {
-    log.Printf("Timeout after %s\n", timeoutErr.Duration)
+    log.Printf("Operation timed out: %v", err)
+    // Error message includes timeout duration
 }
 
 ## Examples

--- a/errors.go
+++ b/errors.go
@@ -37,7 +37,12 @@ func (e *ConversionError) Unwrap() error {
 
 // TimeoutError represents execution timeout
 type TimeoutError struct {
+	// Duration is the timeout duration configured for the pipeline via WithTimeout.
+	// Note: This reflects the configured timeout, not necessarily the actual elapsed time
+	// before the timeout occurred. If the context deadline comes from a parent context
+	// with a shorter deadline, this duration may be longer than the actual time elapsed.
 	Duration time.Duration
+	// Err is the underlying error (typically context.DeadlineExceeded)
 	Err      error
 }
 

--- a/errors.go
+++ b/errors.go
@@ -43,7 +43,7 @@ type TimeoutError struct {
 	// with a shorter deadline, this duration may be longer than the actual time elapsed.
 	Duration time.Duration
 	// Err is the underlying error (typically context.DeadlineExceeded)
-	Err      error
+	Err error
 }
 
 func (e *TimeoutError) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -2,7 +2,6 @@ package jqyaml
 
 import (
 	"fmt"
-	"time"
 )
 
 // QueryError represents a jq query compilation or execution error
@@ -32,27 +31,5 @@ func (e *ConversionError) Error() string {
 }
 
 func (e *ConversionError) Unwrap() error {
-	return e.Err
-}
-
-// TimeoutError represents execution timeout
-type TimeoutError struct {
-	// Duration is the timeout duration configured for the pipeline via WithTimeout.
-	// Note: This reflects the configured timeout, not necessarily the actual elapsed time
-	// before the timeout occurred. If the context deadline comes from a parent context
-	// with a shorter deadline, this duration may be longer than the actual time elapsed.
-	Duration time.Duration
-	// Err is the underlying error (typically context.DeadlineExceeded)
-	Err error
-}
-
-func (e *TimeoutError) Error() string {
-	if e.Err != nil {
-		return fmt.Sprintf("execution timeout after %s: %v", e.Duration, e.Err)
-	}
-	return fmt.Sprintf("execution timeout after %s", e.Duration)
-}
-
-func (e *TimeoutError) Unwrap() error {
 	return e.Err
 }

--- a/errors.go
+++ b/errors.go
@@ -38,8 +38,16 @@ func (e *ConversionError) Unwrap() error {
 // TimeoutError represents execution timeout
 type TimeoutError struct {
 	Duration time.Duration
+	Err      error
 }
 
 func (e *TimeoutError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("execution timeout after %s: %v", e.Duration, e.Err)
+	}
 	return fmt.Sprintf("execution timeout after %s", e.Duration)
+}
+
+func (e *TimeoutError) Unwrap() error {
+	return e.Err
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,11 +1,9 @@
 package jqyaml_test
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	jqyaml "github.com/apstndb/go-jq-yamlformat"
 )
@@ -47,61 +45,12 @@ func TestConversionError(t *testing.T) {
 	}
 }
 
-func TestTimeoutError(t *testing.T) {
-	t.Run("without wrapped error", func(t *testing.T) {
-		err := &jqyaml.TimeoutError{
-			Duration: 5 * time.Second,
-		}
-
-		want := "execution timeout after 5s"
-		if got := err.Error(); got != want {
-			t.Errorf("Error() = %q, want %q", got, want)
-		}
-	})
-
-	t.Run("with wrapped error", func(t *testing.T) {
-		err := &jqyaml.TimeoutError{
-			Duration: 5 * time.Second,
-			Err:      context.DeadlineExceeded,
-		}
-
-		want := "execution timeout after 5s: context deadline exceeded"
-		if got := err.Error(); got != want {
-			t.Errorf("Error() = %q, want %q", got, want)
-		}
-
-		// Test Unwrap
-		if unwrapped := err.Unwrap(); unwrapped != context.DeadlineExceeded {
-			t.Errorf("Unwrap() = %v, want %v", unwrapped, context.DeadlineExceeded)
-		}
-
-		// Test errors.Is
-		if !errors.Is(err, context.DeadlineExceeded) {
-			t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
-		}
-
-		// Test errors.As - verify the error type and contents are correctly preserved
-		var timeoutErr *jqyaml.TimeoutError
-		if !errors.As(err, &timeoutErr) {
-			t.Fatalf("errors.As(err, &timeoutErr) = false, want true")
-		}
-		if timeoutErr.Duration != 5*time.Second {
-			t.Errorf("timeoutErr.Duration = %v, want %v", timeoutErr.Duration, 5*time.Second)
-		}
-		if timeoutErr.Err != context.DeadlineExceeded {
-			t.Errorf("timeoutErr.Err = %v, want %v", timeoutErr.Err, context.DeadlineExceeded)
-		}
-	})
-}
-
 func TestErrorTypes(t *testing.T) {
 	// Ensure error types implement error interface
 	var _ error = (*jqyaml.QueryError)(nil)
 	var _ error = (*jqyaml.ConversionError)(nil)
-	var _ error = (*jqyaml.TimeoutError)(nil)
 
 	// Ensure error types implement unwrap
 	var _ interface{ Unwrap() error } = (*jqyaml.QueryError)(nil)
 	var _ interface{ Unwrap() error } = (*jqyaml.ConversionError)(nil)
-	var _ interface{ Unwrap() error } = (*jqyaml.TimeoutError)(nil)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package jqyaml_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -47,14 +48,38 @@ func TestConversionError(t *testing.T) {
 }
 
 func TestTimeoutError(t *testing.T) {
-	err := &jqyaml.TimeoutError{
-		Duration: 5 * time.Second,
-	}
+	t.Run("without wrapped error", func(t *testing.T) {
+		err := &jqyaml.TimeoutError{
+			Duration: 5 * time.Second,
+		}
 
-	want := "execution timeout after 5s"
-	if got := err.Error(); got != want {
-		t.Errorf("Error() = %q, want %q", got, want)
-	}
+		want := "execution timeout after 5s"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with wrapped error", func(t *testing.T) {
+		err := &jqyaml.TimeoutError{
+			Duration: 5 * time.Second,
+			Err:      context.DeadlineExceeded,
+		}
+
+		want := "execution timeout after 5s: context deadline exceeded"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+
+		// Test Unwrap
+		if unwrapped := err.Unwrap(); unwrapped != context.DeadlineExceeded {
+			t.Errorf("Unwrap() = %v, want %v", unwrapped, context.DeadlineExceeded)
+		}
+
+		// Test errors.Is
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+		}
+	})
 }
 
 func TestErrorTypes(t *testing.T) {
@@ -63,7 +88,8 @@ func TestErrorTypes(t *testing.T) {
 	var _ error = (*jqyaml.ConversionError)(nil)
 	var _ error = (*jqyaml.TimeoutError)(nil)
 
-	// Ensure QueryError and ConversionError implement unwrap
+	// Ensure error types implement unwrap
 	var _ interface{ Unwrap() error } = (*jqyaml.QueryError)(nil)
 	var _ interface{ Unwrap() error } = (*jqyaml.ConversionError)(nil)
+	var _ interface{ Unwrap() error } = (*jqyaml.TimeoutError)(nil)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -83,9 +83,13 @@ func TestTimeoutError(t *testing.T) {
 		// Test errors.As - verify the error type and contents are correctly preserved
 		var timeoutErr *jqyaml.TimeoutError
 		if !errors.As(err, &timeoutErr) {
-			t.Errorf("errors.As(err, &timeoutErr) = false, want true")
-		} else if timeoutErr.Duration != 5*time.Second {
+			t.Fatalf("errors.As(err, &timeoutErr) = false, want true")
+		}
+		if timeoutErr.Duration != 5*time.Second {
 			t.Errorf("timeoutErr.Duration = %v, want %v", timeoutErr.Duration, 5*time.Second)
+		}
+		if timeoutErr.Err != context.DeadlineExceeded {
+			t.Errorf("timeoutErr.Err = %v, want %v", timeoutErr.Err, context.DeadlineExceeded)
 		}
 	})
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -79,6 +79,14 @@ func TestTimeoutError(t *testing.T) {
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
 		}
+
+		// Test errors.As - verify the error type and contents are correctly preserved
+		var timeoutErr *jqyaml.TimeoutError
+		if !errors.As(err, &timeoutErr) {
+			t.Errorf("errors.As(err, &timeoutErr) = false, want true")
+		} else if timeoutErr.Duration != 5*time.Second {
+			t.Errorf("timeoutErr.Duration = %v, want %v", timeoutErr.Duration, 5*time.Second)
+		}
 	})
 }
 

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -114,6 +114,8 @@ func main() {
 		if errors.Is(err, context.DeadlineExceeded) {
 			log.Printf("Operation timed out: %v", err)
 			// The error message includes the timeout duration
+		} else {
+			log.Printf("Unexpected error in timeout example: %v", err)
 		}
 	}
 

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -115,7 +115,7 @@ func main() {
 		if errors.Is(err, context.DeadlineExceeded) {
 			log.Println("Operation timed out")
 		}
-		
+
 		// 2. Extract TimeoutError to access the configured duration (useful for debugging)
 		var timeoutErr *jqyaml.TimeoutError
 		if errors.As(err, &timeoutErr) {

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -153,14 +153,14 @@ func handleError(err error) {
 	var convErr *jqyaml.ConversionError
 
 	switch {
-	case errors.As(err, &queryErr):
-		log.Println("This is a query-related error. Check your jq syntax.")
-	case errors.As(err, &convErr):
-		log.Println("This is a data conversion error. Check your data types.")
 	case errors.Is(err, context.DeadlineExceeded):
 		log.Println("The operation timed out. Consider increasing the timeout or optimizing the query.")
 	case errors.Is(err, context.Canceled):
 		log.Println("Context was canceled.")
+	case errors.As(err, &queryErr):
+		log.Println("This is a query-related error. Check your jq syntax.")
+	case errors.As(err, &convErr):
+		log.Println("This is a data conversion error. Check your data types.")
 	default:
 		log.Println("An unexpected error occurred.")
 	}

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -110,17 +110,10 @@ func main() {
 		jqyaml.WithTimeout(100*time.Millisecond),
 	)
 	if err != nil {
-		// You can check for timeout in two ways:
-		// 1. Simple check using errors.Is (when you just need to know if it timed out)
+		// Check for timeout using errors.Is
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Println("Operation timed out")
-		}
-
-		// 2. Extract TimeoutError to access the configured duration (useful for debugging)
-		var timeoutErr *jqyaml.TimeoutError
-		if errors.As(err, &timeoutErr) {
-			log.Printf("Timeout Error: %v\n", timeoutErr)
-			log.Printf("  Configured timeout was: %v\n", timeoutErr.Duration)
+			log.Printf("Operation timed out: %v", err)
+			// The error message includes the timeout duration
 		}
 	}
 
@@ -158,20 +151,14 @@ func handleError(err error) {
 	// Check for specific error types
 	var queryErr *jqyaml.QueryError
 	var convErr *jqyaml.ConversionError
-	var timeoutErr *jqyaml.TimeoutError
 
 	switch {
 	case errors.As(err, &queryErr):
 		log.Println("This is a query-related error. Check your jq syntax.")
 	case errors.As(err, &convErr):
 		log.Println("This is a data conversion error. Check your data types.")
-	case errors.As(err, &timeoutErr):
-		// Use TimeoutError when you need access to the configured timeout duration
-		log.Printf("The operation timed out after %v. Consider increasing the timeout or optimizing the query.", timeoutErr.Duration)
 	case errors.Is(err, context.DeadlineExceeded):
-		// This case won't be reached for jqyaml timeouts (they're wrapped in TimeoutError)
-		// but could happen for other deadline-exceeded errors from parent contexts
-		log.Println("Context deadline exceeded.")
+		log.Println("The operation timed out. Consider increasing the timeout or optimizing the query.")
 	case errors.Is(err, context.Canceled):
 		log.Println("Context was canceled.")
 	default:

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -110,10 +110,17 @@ func main() {
 		jqyaml.WithTimeout(100*time.Millisecond),
 	)
 	if err != nil {
+		// You can check for timeout in two ways:
+		// 1. Simple check using errors.Is (when you just need to know if it timed out)
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Println("Operation timed out")
+		}
+		
+		// 2. Extract TimeoutError to access the configured duration (useful for debugging)
 		var timeoutErr *jqyaml.TimeoutError
 		if errors.As(err, &timeoutErr) {
 			log.Printf("Timeout Error: %v\n", timeoutErr)
-			log.Printf("  Duration: %v\n", timeoutErr.Duration)
+			log.Printf("  Configured timeout was: %v\n", timeoutErr.Duration)
 		}
 	}
 
@@ -159,8 +166,11 @@ func handleError(err error) {
 	case errors.As(err, &convErr):
 		log.Println("This is a data conversion error. Check your data types.")
 	case errors.As(err, &timeoutErr):
-		log.Println("The operation timed out. Consider increasing the timeout or optimizing the query.")
+		// Use TimeoutError when you need access to the configured timeout duration
+		log.Printf("The operation timed out after %v. Consider increasing the timeout or optimizing the query.", timeoutErr.Duration)
 	case errors.Is(err, context.DeadlineExceeded):
+		// This case won't be reached for jqyaml timeouts (they're wrapped in TimeoutError)
+		// but could happen for other deadline-exceeded errors from parent contexts
 		log.Println("Context deadline exceeded.")
 	case errors.Is(err, context.Canceled):
 		log.Println("Context was canceled.")

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -119,8 +120,8 @@ func main() { //nolint:gocyclo // Example code demonstrating multiple use cases
 		jqyaml.WithTimeout(100*time.Millisecond),
 	)
 	if err != nil {
-		if _, ok := err.(*jqyaml.TimeoutError); ok {
-			log.Printf("Processing timed out after processing %d items\n", processed)
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Printf("Processing timed out after processing %d items: %v\n", processed, err)
 		} else {
 			log.Fatal(err)
 		}

--- a/jqyaml.go
+++ b/jqyaml.go
@@ -225,6 +225,9 @@ func (p *pipeline) streamingProcess(ctx context.Context, data interface{}, varia
 				// Wrap the error with timeout duration information
 				return fmt.Errorf("execution timeout after %s: %w", timeout, err)
 			}
+			if errors.Is(err, context.Canceled) {
+				return fmt.Errorf("execution canceled: %w", err)
+			}
 			return &QueryError{
 				Query:   p.query,
 				Message: "execution error",

--- a/jqyaml.go
+++ b/jqyaml.go
@@ -221,7 +221,7 @@ func (p *pipeline) streamingProcess(ctx context.Context, data interface{}, varia
 		}
 		if err, ok := v.(error); ok {
 			if err == context.DeadlineExceeded {
-				return &TimeoutError{Duration: timeout}
+				return &TimeoutError{Duration: timeout, Err: err}
 			}
 			return &QueryError{
 				Query:   p.query,

--- a/jqyaml.go
+++ b/jqyaml.go
@@ -222,11 +222,8 @@ func (p *pipeline) streamingProcess(ctx context.Context, data interface{}, varia
 		}
 		if err, ok := v.(error); ok {
 			if errors.Is(err, context.DeadlineExceeded) {
-				// Wrap context.DeadlineExceeded in TimeoutError to provide additional context:
-				// - The Duration field shows the configured timeout (via WithTimeout)
-				// - Users can still use errors.Is(err, context.DeadlineExceeded) for simple timeout checks
-				// - Or use errors.As(err, &TimeoutError) to access the Duration for logging/debugging
-				return &TimeoutError{Duration: timeout, Err: err}
+				// Wrap the error with timeout duration information
+				return fmt.Errorf("execution timeout after %s: %w", timeout, err)
 			}
 			return &QueryError{
 				Query:   p.query,

--- a/jqyaml.go
+++ b/jqyaml.go
@@ -4,6 +4,7 @@ package jqyaml
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -220,7 +221,7 @@ func (p *pipeline) streamingProcess(ctx context.Context, data interface{}, varia
 			break
 		}
 		if err, ok := v.(error); ok {
-			if err == context.DeadlineExceeded {
+			if errors.Is(err, context.DeadlineExceeded) {
 				// Wrap context.DeadlineExceeded in TimeoutError to provide additional context:
 				// - The Duration field shows the configured timeout (via WithTimeout)
 				// - Users can still use errors.Is(err, context.DeadlineExceeded) for simple timeout checks

--- a/jqyaml.go
+++ b/jqyaml.go
@@ -221,6 +221,10 @@ func (p *pipeline) streamingProcess(ctx context.Context, data interface{}, varia
 		}
 		if err, ok := v.(error); ok {
 			if err == context.DeadlineExceeded {
+				// Wrap context.DeadlineExceeded in TimeoutError to provide additional context:
+				// - The Duration field shows the configured timeout (via WithTimeout)
+				// - Users can still use errors.Is(err, context.DeadlineExceeded) for simple timeout checks
+				// - Or use errors.As(err, &TimeoutError) to access the Duration for logging/debugging
 				return &TimeoutError{Duration: timeout, Err: err}
 			}
 			return &QueryError{

--- a/jqyaml_test.go
+++ b/jqyaml_test.go
@@ -271,12 +271,14 @@ func TestTimeout(t *testing.T) {
 		t.Fatal("expected timeout error, got nil")
 	}
 
-	// Check if it's a timeout-related error
+	// Check that the error wraps context.DeadlineExceeded
 	if !errors.Is(err, context.DeadlineExceeded) {
-		var timeoutErr *jqyaml.TimeoutError
-		if !errors.As(err, &timeoutErr) {
-			t.Errorf("expected TimeoutError or context.DeadlineExceeded, got %T: %v", err, err)
-		}
+		t.Errorf("expected error to wrap context.DeadlineExceeded, got %T: %v", err, err)
+	}
+
+	// Check that the error message includes timeout duration
+	if !strings.Contains(err.Error(), "50ms") {
+		t.Errorf("expected error message to contain timeout duration '50ms', got: %v", err)
 	}
 }
 

--- a/jqyaml_test.go
+++ b/jqyaml_test.go
@@ -276,9 +276,10 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("expected error to wrap context.DeadlineExceeded, got %T: %v", err, err)
 	}
 
-	// Check that the error message includes timeout duration
-	if !strings.Contains(err.Error(), "50ms") {
-		t.Errorf("expected error message to contain timeout duration '50ms', got: %v", err)
+	// Check the exact error message for better test precision
+	want := "execution timeout after 50ms: context deadline exceeded"
+	if got := err.Error(); got != want {
+		t.Errorf("expected error message %q, got %q", want, got)
 	}
 }
 

--- a/jqyaml_test.go
+++ b/jqyaml_test.go
@@ -284,6 +284,38 @@ func TestTimeout(t *testing.T) {
 	}
 }
 
+func TestContextCanceled(t *testing.T) {
+	p, err := jqyaml.New(jqyaml.WithQuery("while(true; .+1)")) // Infinite loop
+	if err != nil {
+		t.Fatalf("failed to create pipeline: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	
+	// Cancel immediately
+	cancel()
+
+	var buf bytes.Buffer
+	err = p.Execute(ctx, 0,
+		jqyaml.WithWriter(&buf, yamlformat.FormatJSON),
+	)
+
+	if err == nil {
+		t.Fatal("expected context canceled error, got nil")
+	}
+
+	// Check that the error wraps context.Canceled
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error to wrap context.Canceled, got %T: %v", err, err)
+	}
+
+	// Check that the error message includes cancellation information
+	wantPrefix := "execution canceled:"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("expected error message to start with %q, got %q", wantPrefix, err.Error())
+	}
+}
+
 func TestCustomMarshaler(t *testing.T) {
 	t.Skip("Custom marshaler for input data conversion is not yet supported")
 	// TODO: This test is currently failing because the custom marshaler

--- a/jqyaml_test.go
+++ b/jqyaml_test.go
@@ -291,7 +291,7 @@ func TestContextCanceled(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	// Cancel immediately
 	cancel()
 

--- a/jqyaml_test.go
+++ b/jqyaml_test.go
@@ -276,10 +276,11 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("expected error to wrap context.DeadlineExceeded, got %T: %v", err, err)
 	}
 
-	// Check the exact error message for better test precision
-	want := "execution timeout after 50ms: context deadline exceeded"
-	if got := err.Error(); got != want {
-		t.Errorf("expected error message %q, got %q", want, got)
+	// Check that the error message contains the timeout information.
+	// We already confirmed it wraps context.DeadlineExceeded.
+	wantPrefix := "execution timeout after 50ms:"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("expected error message to start with %q, got %q", wantPrefix, err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR simplifies timeout error handling by removing the custom `TimeoutError` type and using `fmt.Errorf` to wrap `context.DeadlineExceeded`, enabling idiomatic Go error checking with `errors.Is()`.

## Problem
Previously, when a jq query execution timed out, the library returned a custom `TimeoutError` that didn't properly wrap the underlying `context.DeadlineExceeded` error. This made it impossible to use the standard Go pattern:
```go
if errors.Is(err, context.DeadlineExceeded) {
    // Handle timeout
}
```

## Solution
After initial implementation and review discussions, we decided to simplify the approach:
- **Removed** the custom `TimeoutError` type entirely
- **Replaced** with `fmt.Errorf("execution timeout after %s: %w", timeout, err)` to wrap `context.DeadlineExceeded`
- This allows standard `errors.Is(err, context.DeadlineExceeded)` checks to work correctly
- The timeout duration is preserved in the error message

## Benefits
- Simpler code - no custom error type needed
- Follows Go best practices for error wrapping
- Enables idiomatic timeout checking with `errors.Is()`
- Timeout duration still available in error message

## Testing
- Updated tests to verify `errors.Is(err, context.DeadlineExceeded)` works correctly
- Removed tests for the now-deleted `TimeoutError` type
- All existing tests continue to pass

## Breaking Change Note
This removes the public `TimeoutError` type. However, since the package has no released version, backward compatibility is not a concern.

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)